### PR TITLE
Unlock the GIL when destroying DNP3Manager.

### DIFF
--- a/examples/master.py
+++ b/examples/master.py
@@ -143,6 +143,7 @@ class MyMaster:
         del self.master
         del self.channel
         self.manager.Shutdown()
+        del self.manager
 
 
 class MyLogger(openpal.ILogHandler):


### PR DESCRIPTION
When running pydnp3 I found there was a double-delete on application exit. The root cause of this is the call to the destructor from Shutdown. When Python then cleans up the object the destructor is called again. However, removing the destructor call resulted in a hang. This issue is described in detail at the link below, my solution is borrowed from the comments there.

https://github.com/pybind/pybind11/issues/1446

I did change the ownership of the DNP3Manager from a shared_ptr to a unique_ptr to simplify adding the custom deleter. Since the object is wholely owned by Python anyway, I believe this to be OK.

To reproduce this, run the master_cmd.py script, wait for the command prompt to appear then type 'quit'. Application will terminate with an error.