### PR TITLE
Set RPATH to $ORIGIN so shared objects can be found after installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ include_directories(deps/dnp3/cpp/libs/src)
 include_directories(deps/dnp3/deps/asio/asio/include)
 add_definitions(-DASIO_STANDALONE)
 
+# Linux only!
+# target_link_options has a bug for "$"; see
+# https://discourse.cmake.org/t/how-not-to-have-dollar-sign-in-target-link-options-mangled/3939/5
+set(CMAKE_MODULE_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
+
 pybind11_add_module(pydnp3 MODULE src/pydnp3.cpp src/pydnp3asiodnp3.cpp src/pydnp3asiopal.cpp src/pydnp3opendnp3.cpp src/pydnp3openpal.cpp)
 target_link_libraries(pydnp3 PRIVATE asiopal asiodnp3 openpal opendnp3)
 


### PR DESCRIPTION
This is a bare-bones commit that allows wheels to work on Linux.  It needs some CMake fixes, e.g., gating the extra flag on CMAKE_SYSTEM_NAME being equal to Linux.

I believe there's another way to achieve the same thing, namely adding an `__init__.py` (or similar) and using ctypes to preload the SOs, since they will be in a fixed location relative to that Python source file.

While I *think* the auditwheel package might do something similar to (or better than!) this, it doesn't support ARM platforms, and we need pydnp3 on a Raspberry Pi-based system.