### PR TITLE
Use upstream pybind11 instead of old pybind11 2.3.dev0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "deps/pybind11"]
-	path = deps/pybind11
-	url = https://github.com/Kisensum/pybind11.git
 [submodule "deps/dnp3"]
 	path = deps/dnp3
 	url = https://github.com/automatak/dnp3.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs==17.4.0
-cmake==0.9.0
 funcsigs==1.0.2
 pluggy==0.6.0
 py==1.5.2
 pytest==3.4.0
 six==1.11.0
+pybind11==2.9.1

--- a/reset_pybind11_submodule.sh
+++ b/reset_pybind11_submodule.sh
@@ -1,7 +1,0 @@
-git rm --cached deps/pybind11
-rm -rf .git/modules/deps/pybind11
-rm -rf deps/pybind11
-cd deps
-git submodule add https://github.com/Kisensum/pybind11.git
-git submodule update --init --recursive
-cd ..


### PR DESCRIPTION
pydnp3 is using an old version of pybind11 that is using some deprecated pthread features it seems, and causes segfaults. Using the most recent pybind11 fixes this. I don't think there's any reason pybind11 should be a submodule, it can just be a dependency instead, as the latest version 2.9.1 is available from pip.

cmake is deleted because it does not compile, and does not seem to be needed as a python module. You just need your system's cmake.